### PR TITLE
Fix ruby "remove top-level constant lookup" issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.gem
 *.rbc
 /.config

--- a/lib/pulsar_sdk.rb
+++ b/lib/pulsar_sdk.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'json'
+require 'uri'
 require 'protobuf/validate'
 require 'protobuf/pulsar_api.pb'
 require "pulsar_sdk/version"

--- a/lib/pulsar_sdk/options/connection.rb
+++ b/lib/pulsar_sdk/options/connection.rb
@@ -13,7 +13,7 @@ module PulsarSdk
       [:logical_addr, :physical_addr].each do |x|
         define_method "#{x}=" do |v|
           return instance_variable_set("@#{x}", v) if v.nil?
-          v = v.is_a?(URI) ? v : URI.parse(v)
+          v = v.is_a?(::URI) ? v : ::URI.parse(v)
           v.port = DEFAULT_PORT if v.port.nil?
           instance_variable_set("@#{x}", v)
         end

--- a/pulsar_sdk.gemspec
+++ b/pulsar_sdk.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'digest-crc', '~> 0.4'
 
   spec.add_development_dependency "bundler", "> 1.17"
+  spec.add_development_dependency "rake", "~> 10"
 end


### PR DESCRIPTION
ruby 2.5 has removed top level constant lookup. so when use `URI.parse` in ruby 2.5+ will raise `NameError: uninitialized constant URI`. 

to fix this:
1. require the uri module
2. use `::URI` instead of `URI`